### PR TITLE
Force linear_interpolate to do floating division

### DIFF
--- a/bin/user/aqi/calculators.py
+++ b/bin/user/aqi/calculators.py
@@ -65,7 +65,7 @@ def validate_number_of_observations(observations, duration_in_secs, obs_frequenc
 def linear_interoplate(breakpoint, obs_mean):
     numerator = (obs_mean - breakpoint['low_obs']) * (breakpoint['high_aqi'] - breakpoint['low_aqi'])
     denominator = breakpoint['high_obs'] - breakpoint['low_obs']
-    return int(round((numerator / denominator) + breakpoint['low_aqi']))
+    return int(round((numerator / float(denominator)) + breakpoint['low_aqi']))
 
 def arithmetic_mean(observations):
     '''Calculates the arithmetic mean from a set of observations.


### PR DESCRIPTION
Under Python 2, which weewx 3 uses, linear_interpolate works properly in the PM2.5 case for US AQI calculations because the breakpoint table happens to use floating point values for high and low observations. In python 2, (int/float) returns a float. Some of the other pollutants, such as PM10, have integer values in that table for the high and low observations *and* AQI. In Python2 int/int = int, so 7 / 2 = 3 (again, in Python 2). This is noticed when the pollutant level for PM10 is "1", the calculated AQI becomes (50 / 54), resulting in 0, which rounds to 0 of course. The correct result should be (50 / 54) = 0.926, rounded becomes 1. This result can be verified by going to the website https://airnow.gov/index.cfm?action=airnow.calculator - and then choosing the "Concentration to AQI" tab, and PM10 pollutant, concentration "1" - will return "1" and not "0", as the pre-modified weewx-aqi will erroneously produce. This patch is done because fixing it here, in the calculation, is more robust than remembering to make all the "add_breakpoint" calls specify floating point values for observation low/high for all its entries.