### PR TITLE
removed dateTime parameter and replaced with argument

### DIFF
--- a/bin/user/aqi/service.py
+++ b/bin/user/aqi/service.py
@@ -272,7 +272,7 @@ class AqiService(weewx.engine.StdService):
             # See https://github.com/weewx/weewx/wiki/Barometer,-pressure,-and-altimeter
             weather_observations_real_cols = [ 'dateTime', 'outTemp', 'pressure', 'usUnits' ]
             weather_observations_as_cols = [ 'dateTime', 'outTemp', 'pressure', 'weather_usUnits' ]
-            sql = 'SELECT ' + ','.join(weather_observations_real_cols) + ' FROM archive WHERE dateTime >= ? AND %s <= ? ORDER BY %s ASC' % (
+            sql = 'SELECT ' + ','.join(weather_observations_real_cols) + ' FROM archive WHERE %s >= ? AND %s <= ? ORDER BY %s ASC' % (
                 self.sensor_epoch_seconds_column,
                 self.sensor_epoch_seconds_column,
                 self.sensor_epoch_seconds_column)


### PR DESCRIPTION
Run fails with error below, the culprit seems to be one less parameter than expected and one more dateTime

> May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****    File "/weewx/purpleair/bin/weewxd", line 154, in main
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****      engine.run()
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 202, in run
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****      self.dispatchEvent(weewx.Event(weewx.POST_LOOP))
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 224, in dispatchEvent
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****      callback(event)
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 596, in post_loop
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****      self._software_catchup()
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 656, in _software_catchup
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****      self.engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 224, in dispatchEvent
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****      callback(event)
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/user/aqi/service.py", line 281, in new_archive_record
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****      sql = 'SELECT ' + ','.join(weather_observations_real_cols) + ' FROM archive WHERE dateTime >= ? AND %s <= ? ORDER BY %s ASC' % (
May 17 15:00:15 bee weewx-purpleair[1445567] CRITICAL __main__:     ****  TypeError: not all arguments converted during string formatting
