### PR TITLE
List indices

### DIFF
--- a/bin/user/aqi/service.py
+++ b/bin/user/aqi/service.py
@@ -272,7 +272,7 @@ class AqiService(weewx.engine.StdService):
             # See https://github.com/weewx/weewx/wiki/Barometer,-pressure,-and-altimeter
             weather_observations_real_cols = [ 'dateTime', 'outTemp', 'pressure', 'usUnits' ]
             weather_observations_as_cols = [ 'dateTime', 'outTemp', 'pressure', 'weather_usUnits' ]
-            sql = 'SELECT ' + ','.join(weather_observations_real_cols) + ' FROM archive WHERE dateTime >= ? AND %s <= ? ORDER BY %s ASC' % (
+            sql = 'SELECT ' + ','.join(weather_observations_real_cols) + ' FROM archive WHERE %s >= ? AND %s <= ? ORDER BY %s ASC' % (
                 self.sensor_epoch_seconds_column,
                 self.sensor_epoch_seconds_column,
                 self.sensor_epoch_seconds_column)

--- a/bin/user/aqi/us.py
+++ b/bin/user/aqi/us.py
@@ -212,7 +212,7 @@ def nowcast_mean(observations, obs_frequency_in_sec, required_observation_ratio,
     # calculate hourly means
     start_time = observations[0][0]
     for obs in observations:
-        index = (start_time - obs[0]) / calculators.HOUR
+        index = int((start_time - obs[0]) / calculators.HOUR)
         hourly_samples[index] = hourly_samples[index] + 1
         hourly_means[index] = hourly_means[index] + obs[1]
 


### PR DESCRIPTION
When using now cast, run fails with a TypeError. Forced index to be an int

> May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****  Traceback (most recent call last):
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/purpleair/bin/weewxd", line 154, in main
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      engine.run()
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 202, in run
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      self.dispatchEvent(weewx.Event(weewx.POST_LOOP))
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 224, in dispatchEvent
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      callback(event)
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 596, in post_loop
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      self._software_catchup()
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 656, in _software_catchup
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      self.engine.dispatchEvent(weewx.Event(weewx.NEW_ARCHIVE_RECORD,
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/weewx/engine.py", line 224, in dispatchEvent
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      callback(event)
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/user/aqi/service.py", line 340, in new_archive_record
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      self.aqi_standard.calculate_aqi(pollutant, required_unit, joined)
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/user/aqi/standards.py", line 46, in calculate_aqi
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      return self.calculators[pollutant].calculate(pollutant, observation_unit, observations)
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/user/aqi/calculators.py", line 170, in calculate
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      res = table.calculate(pollutant, observation_unit, observations)
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/user/aqi/calculators.py", line 237, in calculate
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      obs_mean = self.mean_cleaner(self.mean_calculator(observations))
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/user/aqi/us.py", line 281, in <lambda>
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      mean_calculator=lambda obs: nowcast_mean(obs, obs_frequency_in_sec, 0.75, 2),
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****    File "/weewx/package/weewx-4.0.0/bin/user/aqi/us.py", line 216, in nowcast_mean
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****      hourly_samples[index] = hourly_samples[index] + 1
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****  TypeError: list indices must be integers or slices, not float
May 18 00:45:15 bee weewx-purpleair[1454064] CRITICAL __main__:     ****  Exiting.
