### PR TITLE
Handle Missing Pollution Units & py2 backwards compat

### DIFF
--- a/bin/aqi_backfill
+++ b/bin/aqi_backfill
@@ -5,13 +5,15 @@
 # License: GPL 3
 
 import argparse
+import datetime
 import sys
 
+import weecfg
 import weewx
 import weewx.engine
 import user.aqi.service
 import weeutil.weeutil
-import schemas
+import schemas.wview
 
 
 parser = argparse.ArgumentParser(
@@ -31,7 +33,7 @@ parser.add_argument('--end_time',
 args = parser.parse_args()
 
 
-config = weewx.engine.getConfiguration(args.config_file)
+config_path, config = weecfg.read_config(args.config_file, [])
 engine = weewx.engine.StdEngine(config)
 service = user.aqi.service.AqiService(engine, config)
 
@@ -39,16 +41,15 @@ wx_db = engine.db_binder.get_manager(data_binding='wx_binding', initialize=True)
 wx_column_names = [x[0] for x in schemas.wview.schema]
 num_wx_cols = len(wx_column_names)
 
-
 sql = 'SELECT * FROM archive WHERE dateTime >= %d AND datetime < %d ORDER BY dateTime ASC' % (args.start_time, args.end_time)
-print 'Starting backfill from %d' % (args.start_time)
+print('Starting backfill from %d %s' % (args.start_time, str(datetime.datetime.fromtimestamp(args.start_time))))
 total_intervals = 0
 for row in wx_db.genSql(sql):
     record = {}
     for i in range(num_wx_cols):
         record[wx_column_names[i]] = row[i]
     total_intervals += record['interval']
-    if total_intervals % 1440 == 0:
-        print 'processed %d days...' % (total_intervals / 1440)
+    if (total_intervals % (1440 * 30)) == 0:
+        print('processed %d days... %d %s' % (total_intervals / 1440,  record['dateTime'], str(datetime.datetime.fromtimestamp(record['dateTime']))))
     event = weewx.Event(weewx.NEW_ARCHIVE_RECORD, record=record)
     service.new_archive_record(event)

--- a/bin/user/aqi/ca.py
+++ b/bin/user/aqi/ca.py
@@ -26,7 +26,7 @@ class AirQualityHealthIndex(standards.AqiStandards):
         super(AirQualityHealthIndex, self).__init__(
             [COLOR_1, COLOR_2, COLOR_3, COLOR_4, COLOR_5, COLOR_6, COLOR_7, COLOR_8, COLOR_9, COLOR_10, COLOR_PLUS],
             ['Low', 'Low', 'Low', 'Moderate', 'Moderate', 'Moderate', 'High', 'High', 'High', 'High', 'Very High'],
-            1)
+            standards.CA_AQHI_GUID)
         self.calculators[calculators.O3] = calculators.ArithmeticMean(
             unit='parts_per_billion',
             duration_in_secs=3 * calculators.HOUR,

--- a/bin/user/aqi/calculators.py
+++ b/bin/user/aqi/calculators.py
@@ -5,6 +5,8 @@
 from abc import ABCMeta, abstractmethod
 import operator
 
+from six import with_metaclass
+
 # number of seconds
 MINUTE = 60
 HOUR = 3600
@@ -77,7 +79,7 @@ def arithmetic_mean(observations):
         obs_mean = obs_mean + obs[1]
     return obs_mean / float(len(observations))
 
-class AqiCalculator(metaclass=ABCMeta):
+class AqiCalculator(with_metaclass(ABCMeta)):
     def __init__(self, **kwargs):
         '''Creates a new AqiCalculator. Takes the following keyword arguments:
             data_cleaner

--- a/bin/user/aqi/calculators.py
+++ b/bin/user/aqi/calculators.py
@@ -4,6 +4,7 @@
 
 from abc import ABCMeta, abstractmethod
 import operator
+import syslog
 
 from six import with_metaclass
 
@@ -224,8 +225,15 @@ class BreakpointTable(AqiCalculator):
 
         # clean the data
         observations = sorted(observations, key=operator.itemgetter('dateTime'), reverse=True)
+        clean_observations = []
         for i in range(len(observations)):
-            observations[i] = (observations[i]['dateTime'], self.data_cleaner(observations[i][pollutant]))
+            if observations[i][pollutant] is None:
+                continue
+            try:
+                clean_observations.append((observations[i]['dateTime'], self.data_cleaner(observations[i][pollutant])))
+            except TypeError as e:
+                syslog.syslog(syslog.LOG_WARNING, "%s at %d threw exception %s" % (pollutant, observations[i]['dateTime'], str(e)))
+        observations = clean_observations
 
         # validate observations
         last_valid_index = get_last_valid_index(observations, self.duration_in_secs)

--- a/bin/user/aqi/india.py
+++ b/bin/user/aqi/india.py
@@ -28,7 +28,7 @@ class NationalAirQualityIndex(standards.AqiStandards):
         super(NationalAirQualityIndex, self).__init__(
             [GREEN, LIGHT_GREEN, PINK, ORANGE, RED, DARK_RED],
             ['Good', 'Satisfactory', 'Moderately Polluted', 'Poor', 'Very Poor', 'Severe'],
-            2)
+            standards.IN_NAQI_GUID)
 
         self.calculators[calculators.PM10_0] = calculators.AqiTable()
         self.calculators[calculators.PM10_0].add_breakpoint_table(calculators.BreakpointTable(

--- a/bin/user/aqi/mx.py
+++ b/bin/user/aqi/mx.py
@@ -25,7 +25,7 @@ class IndiceMetropolitanoCalidadAire(standards.AqiStandards):
         super(IndiceMetropolitanoCalidadAire, self).__init__(
             [GREEN, YELLOW, ORANGE, RED, PURPLE],
             ['Good', 'Regular', 'Bad', 'Very Bad', 'Extremely Bad'],
-            3)
+            standards.MX_IMCA_GUID)
         self.obs_frequency_in_sec = obs_frequency_in_sec
 
         self.calculators[calculators.O3] = calculators.AqiTable()

--- a/bin/user/aqi/service.py
+++ b/bin/user/aqi/service.py
@@ -49,6 +49,8 @@ def _trim_dict(d):
     return d
 
 def _make_dict(row, colnames):
+    if type(row) == dict:
+        return row
     d = {}
     for i in range(len(row)):
         d[colnames[i]] = row[i]
@@ -134,9 +136,7 @@ class AqiService(weewx.engine.StdService):
         self.use_weather_temp = (self.sensor_temp_column is None)
         self.use_weather_pressure = (self.sensor_pressure_column is None)
         self.weather_us_units = weewx.units.unit_constants[config_dict['StdConvert']['target_unit']]
-
-        # get the sensor binding
-        self.sensor_dbm = self.engine.db_binder.get_manager(data_binding=sensor_config_dict['data_binding'], initialize=False)
+        self.weather_dbm = self.engine.db_binder.get_manager()
 
         # confirm the sensor schema
         dbcols_set = set(self.sensor_dbm.connection.columnsOf(self.sensor_dbm.table_name))
@@ -174,9 +174,7 @@ class AqiService(weewx.engine.StdService):
             'pressure': self.sensor_pressure_column,
         })
 
-    def _join_sensor_results(self, pollutant_observations, pollutant_cols,
-        weather_observations, weather_cols,
-        epsilon):
+    def _join_sensor_results(self, pollutant_observations, pollutant_cols, weather_observations, weather_cols, epsilon):
         '''Returns an array containing the join of the pollutant and weather
         observations. All joined observations must have occured within epsilon
         seconds of each other.'''
@@ -190,7 +188,7 @@ class AqiService(weewx.engine.StdService):
                     # close enough.
                     d = dict.copy(po)
                     for (k, v) in list(wo.items()):
-                        if k not in d:
+                        if k not in d or d[k] is None:
                             d[k] = v
                     joined.append(d)
                     po = _make_dict(next(pollutant_observations), pollutant_cols)
@@ -203,6 +201,7 @@ class AqiService(weewx.engine.StdService):
                     po = _make_dict(next(pollutant_observations), pollutant_cols)
         except StopIteration:
             pass
+
         return joined
 
     def shutDown(self):
@@ -268,15 +267,20 @@ class AqiService(weewx.engine.StdService):
             weather_observations = self.sensor_dbm.genSql(sql, (start_time, end_time))
         else:
             # We can't get the weather data from the air sensor, so use the main sensor instead
-            # We're using "raw gauge pressure" `pressure`
             # See https://github.com/weewx/weewx/wiki/Barometer,-pressure,-and-altimeter
-            weather_observations_real_cols = [ 'dateTime', 'outTemp', 'pressure', 'usUnits' ]
+            weather_observations_real_cols = [ 'dateTime', 'outTemp', 'barometer', 'usUnits' ]
             weather_observations_as_cols = [ 'dateTime', 'outTemp', 'pressure', 'weather_usUnits' ]
-            sql = 'SELECT ' + ','.join(weather_observations_real_cols) + ' FROM archive WHERE %s >= ? AND %s <= ? ORDER BY %s ASC' % (
-                self.sensor_epoch_seconds_column,
-                self.sensor_epoch_seconds_column,
-                self.sensor_epoch_seconds_column)
-            weather_observations = self.sensor_dbm.genSql(sql, (start_time, end_time))
+            sql = 'SELECT '
+            first = True
+            for i in range(len(weather_observations_real_cols)):
+                real_col = weather_observations_real_cols[i]
+                as_col = weather_observations_as_cols[i]
+                if not first:
+                    sql += ', '
+                sql += real_col + ' AS ' + as_col
+                first = False
+            sql += ' FROM archive WHERE dateTime >= ? AND dateTime <= ? ORDER BY dateTime ASC'
+            weather_observations = self.weather_dbm.genSql(sql, (start_time, end_time))
 
         # we need to be able to map back to underlying column for unit conversion
         as_column_to_real_column = {}
@@ -319,7 +323,7 @@ class AqiService(weewx.engine.StdService):
                     try:
                         obs_unit = get_unit_from_column(as_column_to_real_column[pollutant], row['usUnits'])
                     except KeyError:
-                        syslog.syslog(syslog.LOG_WARNING, "AqiService: AQI calculation could not find unit for column %s, assuming %s" % (as_column_to_real_column[pollutant], required_unit)) 
+                        syslog.syslog(syslog.LOG_WARNING, "AqiService: AQI calculation could not find unit for column %s, assuming %s" % (as_column_to_real_column[pollutant], required_unit))
                         obs_unit = required_unit
                     joined[i][pollutant] = units.convert_pollutant_units(pollutant, row[pollutant], obs_unit, required_unit, temp_kelvin, press_pascals)
 
@@ -336,8 +340,8 @@ class AqiService(weewx.engine.StdService):
                 try:
                     (record['aqi_' + pollutant], record['aqi_' + pollutant + '_category']) = \
                         self.aqi_standard.calculate_aqi(pollutant, required_unit, joined)
-                except ValueError as e:
-                    syslog.syslog(syslog.LOG_ERR, "AqiService: AQI calculation for %s failed: %s" % (pollutant, str(e)))
+                except (ValueError) as e: #, TypeError) as e:
+                    syslog.syslog(syslog.LOG_ERR, "AqiService: %s AQI calculation for %s on %s failed: %s" % (type(e).__name__, pollutant, event.record['dateTime'], str(e)))
                 except NotImplementedError as e:
                     pass
             else:
@@ -346,8 +350,8 @@ class AqiService(weewx.engine.StdService):
             try:
                 (record['aqi_composite'], record['aqi_composite_category']) = \
                     self.aqi_standard.calculate_composite_aqi(self.aqi_standard.get_pollutants(), joined)
-            except ValueError as e:
-                syslog.syslog(syslog.LOG_ERR, "AqiService: AQI calculation for composite failed: %s" % (str(e)))
+            except (ValueError, TypeError) as e:
+                syslog.syslog(syslog.LOG_ERR, "AqiService: %s AQI calculation for composite on %s failed: %s" % (type(e).__name__, event.record['dateTime'], str(e)))
 
         if len(record) > 4:
             self.aqi_dbm.addRecord(record)

--- a/bin/user/aqi/standards.py
+++ b/bin/user/aqi/standards.py
@@ -4,6 +4,8 @@
 
 from abc import ABCMeta, abstractmethod
 
+from six import with_metaclass
+
 from . import calculators
 
 CA_AQHI_GUID = 1
@@ -14,7 +16,7 @@ US_AQI_GUID = 5
 US_NOWCAST_GUID = 6
 EU_AQI_GUID = 7
 
-class AqiStandards(metaclass=ABCMeta):
+class AqiStandards(with_metaclass(ABCMeta)):
     def __init__(self, colors, categories, guid):
         '''Creates an AqiStandard with the specified color and categorical scales.
         self.calculators is initalized to an empty dictionary. It is up to

--- a/bin/user/aqi/standards.py
+++ b/bin/user/aqi/standards.py
@@ -6,7 +6,13 @@ from abc import ABCMeta, abstractmethod
 
 from . import calculators
 
-# last used guid is 6
+CA_AQHI_GUID = 1
+IN_NAQI_GUID = 2
+MX_IMCA_GUID = 3
+UK_DAQI_GUID = 4
+US_AQI_GUID = 5
+US_NOWCAST_GUID = 6
+EU_AQI_GUID = 7
 
 class AqiStandards(metaclass=ABCMeta):
     def __init__(self, colors, categories, guid):

--- a/bin/user/aqi/uk.py
+++ b/bin/user/aqi/uk.py
@@ -26,7 +26,7 @@ class DailyAirQualityIndex(standards.AqiStandards):
         super(DailyAirQualityIndex, self).__init__(
             [COLOR_1, COLOR_2, COLOR_3, COLOR_4, COLOR_5, COLOR_6, COLOR_7, COLOR_8, COLOR_9, COLOR_10],
             ['Low', 'Low', 'Low', 'Moderate', 'Moderate', 'Moderate', 'High', 'High', 'High', 'Very High'],
-            4)
+            standards.UK_DAQI_GUID)
 
         self.calculators[calculators.O3] = calculators.AqiTable()
         self.calculators[calculators.O3].add_breakpoint_table(calculators.BreakpointTable(

--- a/bin/user/aqi/units.py
+++ b/bin/user/aqi/units.py
@@ -27,7 +27,7 @@ def convert_pollutant_units(pollutant, obs_value, obs_unit, required_unit, temp_
 
     if (obs_unit[:9] == 'part_per_') and required_unit.endswith('_per_meter_cubed'):
         if obs_unit == 'part_per_million':
-            obs_value = convert_units(obs_value, obs_unit, 'part_per_billion', temp_in_kelvin, pressure_in_pascals)
+            obs_value = convert_pollutant_units(obs_value, obs_unit, 'part_per_billion', temp_in_kelvin, pressure_in_pascals)
             obs_unit = 'part_per_billion'
         v = ppb_to_microgram_per_meter_cubed(pollutant, obs_value, temp_in_kelvin, pressure_in_pascals)
         v_unit = 'microgram_per_meter_cubed'
@@ -35,7 +35,7 @@ def convert_pollutant_units(pollutant, obs_value, obs_unit, required_unit, temp_
             return v / 1000.0
         else:
             return v
-    elif (obs_unit[:9] == '_per_meter_cubed') and required_unit.endswith('part_per_'):
+    elif (obs_unit[9:] == '_per_meter_cubed') and (required_unit[:9] == 'part_per_'):
         if obs_unit == 'milligram_per_meter_cubed':
             obs_value *= 1000
             obs_unit = 'microgram_per_meter_cubed'
@@ -89,6 +89,8 @@ weewx.units.default_unit_format_dict['air_quality_index'] = '%d'
 weewx.units.default_unit_label_dict['air_quality_index'] = '' # unitless
 
 # unit conversion
+if 'liter' not in weewx.units.conversionDict:
+    weewx.units.conversionDict['liter'] = {}
 weewx.units.conversionDict['liter']['meter_cubed'] = lambda x: x / 1000.0
 weewx.units.conversionDict['meter_cubed'] = { 'liter': lambda x: x * 1000.0 }
 weewx.units.conversionDict['part_per_billion'] = { 'part_per_million': lambda x: x * 1000.0 },

--- a/bin/user/aqi/us.py
+++ b/bin/user/aqi/us.py
@@ -25,7 +25,7 @@ class AirQualityIndex(standards.AqiStandards):
         super(AirQualityIndex, self).__init__(
             [GREEN, YELLOW, ORANGE, RED, PURPLE, MAROON],
             ['Good', 'Moderate', 'Unhealthy for Sensitive Groups', 'Unhealthy', 'Very Unhealthy', 'Hazardous'],
-            5)
+            standards.US_AQI_GUID)
 
         # US doesn't specify number of observations required. lets go with 75% since that's the UK's standard
         self.calculators[calculators.PM2_5] = calculators.AqiTable()
@@ -271,7 +271,7 @@ class NowCast(standards.AqiStandards):
         super(NowCast, self).__init__(
             [GREEN, YELLOW, ORANGE, RED, PURPLE, MAROON],
             ['Good', 'Moderate', 'Unhealthy for Sensitive Groups', 'Unhealthy', 'Very Unhealthy', 'Hazardous'],
-            6)
+            standards.US_NOWCAST_GUID)
 
         # US doesn't specify number of observations required. lets go with 75% since that's the UK's standard
         self.calculators[calculators.PM2_5] = calculators.AqiTable()

--- a/bin/user/aqi/us.py
+++ b/bin/user/aqi/us.py
@@ -221,7 +221,8 @@ def nowcast_mean(observations, obs_frequency_in_sec, required_observation_ratio,
     min_obs = None
     for i in range(len(hourly_means)):
         if hourly_samples[i] >= (calculators.HOUR / obs_frequency_in_sec) * required_observation_ratio:
-            hourly_means[i] = calculators.TRUNCATE_TO_1(hourly_means[i] / float(hourly_samples[i]))
+            if hourly_means[i] is not None:
+                hourly_means[i] = calculators.TRUNCATE_TO_1(hourly_means[i] / float(hourly_samples[i]))
             if (max_obs is None) or (hourly_means[i] > max_obs):
                 max_obs = hourly_means[i]
             if (min_obs is None) or (hourly_means[i] < min_obs):
@@ -235,7 +236,7 @@ def nowcast_mean(observations, obs_frequency_in_sec, required_observation_ratio,
         if hourly_means[i] is None:
             missing = missing + 1
     if missing >= round(min_hours * 0.667):
-        raise ValueError('NowCast AQI could not be calculated for the observations')
+        raise ValueError('NowCast AQI could not be calculated for the observations. Too many missing. Missing %d, which meets or exceeding the limit of %d' % (missing, round(min_hours * 0.667)))
 
     # determine the weights
     weight_factor = 1.0


### PR DESCRIPTION
# Description 
Log whenever the pollution columns do not have units associated with them, but assume they are in the proper units for the standard.

Use real constants for identifying which standard is being calculated instead of magic numbers that you just have to know.

