### PR TITLE
wrap unit conversions in try-catches

### DIFF
--- a/bin/user/aqi/service.py
+++ b/bin/user/aqi/service.py
@@ -318,7 +318,7 @@ class AqiService(weewx.engine.StdService):
             pressure_unit = get_unit_from_column(as_column_to_real_column['pressure'], row['weather_usUnits'])
             press_kilopascals = row['pressure']
             try:
-                if (pressure_unit != 'hPa') and (press_kilopascals is not None):
+                if pressure_unit != 'hPa':
                     press_kilopascals = weewx.units.conversionDict[pressure_unit]['hPa'](press_kilopascals)
                 press_kilopascals /= 10
             except TypeError:

--- a/bin/user/aqi/units.py
+++ b/bin/user/aqi/units.py
@@ -56,14 +56,12 @@ def convert_pollutant_units(pollutant, obs_value, obs_unit, required_unit, temp_
 
 def ppb_to_microgram_per_meter_cubed(pollutant, ppb, sensor_temp_in_kelvin=IDEAL_GAS_TEMP_IN_KELVIN, sensor_pressure_in_kilopascals=IDEAL_GAS_PRESSURE_IN_KILOPASCALS):
     '''Converts parts per billion to micrograms per cubic meters at temperature and pressure'''
-
     ugm3 = ppb * (sensor_pressure_in_kilopascals / GAS_CONSTANT) * MOLAR_MASSES[pollutant] / sensor_temp_in_kelvin
     return round(ugm3, 3)
 
 def microgram_per_meter_cubed_to_ppb(pollutant, ug_per_m3, sensor_temp_in_kelvin=IDEAL_GAS_TEMP_IN_KELVIN, sensor_pressure_in_kilopascals=IDEAL_GAS_PRESSURE_IN_KILOPASCALS):
     '''Converts parts per million to micrograms per cubic meters at temperature and pressure'''
     ppb = (ug_per_m3 * sensor_temp_in_kelvin) / ((sensor_pressure_in_kilopascals / GAS_CONSTANT) * MOLAR_MASSES[pollutant])
-
     return round(ppb, 3)
 
 # Define unit group for AQI columns


### PR DESCRIPTION
If temperature or pressure is unavailable, no AQI can be calculated, even if we don't need to convert units from ratios (e.g. ppm) to densities (e.g. mg/m^3)

This addresses https://github.com/jonathankoren/weewx-aqi/issues/31